### PR TITLE
small changes to fib, added rust-cookbook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ samples.
 Mostly a learning exercise, with the hope that others will find it useful. Feel
 free to contribute to it by adding other simple examples.
 
+## rust-cookbook
+There is a collection of excellent rust samples available at [rust-cookbook](https://rust-lang-nursery.github.io/rust-cookbook/). Be sure to check those out too!
+
 ## Contributing
 Simply fork the repo and add your own folder with the example, I'll be happy
 to merge it in.

--- a/fibonacci/src/main.rs
+++ b/fibonacci/src/main.rs
@@ -2,27 +2,47 @@
 // Use this syntax to import more than one type from the same root type
 use std::io::{self, Write};
 
-fn fib(n: usize) -> usize {
+fn fib_recursive(n: u64) -> u64 {
     // Compared to C++, in Rust parenthesis around the expression for if/else
     // statements are not necessary. You can use them but the compiler will
     // warn you that they are unnecessary
     if n == 0 {
         // Numeric literals in Rust can be postfixed with the exact name of the
-        // available numeric types, e.g. 1u32 or 2i64
-        return 0usize;
+        // available numeric types, e.g. 1u32 or 2i64, you can also write 1_u32, etc
+        // However, this isn't necessary most of the time, the rust compiler is able
+        // to infer the type.
+        0
+    } else if n == 1 {
+        // Most things in Rust are expressions, this if/else/else statement is
+        // an expression, and we can tell Rust to return it, rather than writing
+        // return 1; here, above, and below.
+        1
+    } else {
+        fib_recursive(n - 1) + fib_recursive(n - 2)
     }
-    else if n == 1 {
-        // Returning values in Rust is also done by writing an expression
-        // rather than
-        // a statement. I.e. you can omit the trailing ";" at the end of the
-        // expression, e.g.:
-        //
-        //   1usize
-        //
-        return 1usize;
-    }
-    else {
-        return fib(n-1usize) + fib(n-2usize);
+}
+
+// A dynamic programming version of fib
+fn fib_dp(n: u64) -> u64 {
+    if n == 0 || n == 1 {
+        n
+    } else {
+        let mut f1 = 0;
+        let mut f2 = 1;
+        let mut total = 0;
+
+        // The underscore here tells Rust to throw away the value, I'm not going to use it.
+        // On the right half of the 'in', I'm writing a range expression. If you're familiar
+        // with python it's like range(2,n+1). The format of x..y is 'half-open', where
+        // x is inclusive and y is exclusive
+        for _ in 2..(n + 1) {
+            total = f1 + f2;
+            f1 = f2;
+            f2 = total;
+        }
+        // again, here, we could have written return total; but it's often
+        // more concise and idiomatic Rust to just write the value
+        total
     }
 }
 
@@ -56,7 +76,9 @@ fn main() {
     //
     // See enums in the Rust book and std::result, std::result::Result for more
     // information
-    io::stdin().read_line(&mut n).expect("Failed to read from STDIN!");
+    io::stdin()
+        .read_line(&mut n)
+        .expect("Failed to read from STDIN!");
 
     // In Rust we can perform variable "shadowing". Here the previous
     // declaration of "n" was of type String but now we declare a new variable
@@ -66,7 +88,9 @@ fn main() {
     //
     // .parse() uses the trait FromStr to determine whether
     // a type supports this operation (converting to something from a String)
-    let n: usize = n.trim().parse().expect("Invalid input!");
+    let n: u64 = n.trim().parse().expect("Invalid input!");
 
-    println!("The computed value is: {}", fib(n));
+
+    println!("The computed value is: {}", fib_recursive(n));
+    println!("The computed value is: {}", fib_dp(n));
 }


### PR DESCRIPTION
I made the fibonacci functions take a u64 instead of a usize, the usize type AFAIK is mainly for indexing pointers, everything else should be u32/u64/i32/i64 for integers (https://stackoverflow.com/questions/29592256/whats-the-difference-between-usize-and-u32). 

I removed the type postfix and the explicit return, this introduces the value of inference and is more idiomatic 'rusty' code.

Added a dynamic programming fib for comparison, it includes a for .. in loop which I think is a nice thing to learn early on.

Also, there is a similar project going on at rust-cookbook (linked in the readme), I highly recommend you check it out! Lots of great stuff there. Perhaps you can find something to contribute there unless your goals here are orthogonal.

Cheers!